### PR TITLE
Add configurable function calling flag

### DIFF
--- a/oasis/files/luci/model/cbi/setting.lua
+++ b/oasis/files/luci/model/cbi/setting.lua
@@ -118,6 +118,12 @@ openrouter_custom_endpoint:depends("openrouter_endpoint_type", common.endpoint.t
 api_key = service:option(Value, "api_key", "API Key")
 api_key.password = true
 
+function_calling = service:option(Flag, "function_calling", "Function Calling / Tool Use")
+function_calling.enabled = "1"
+function_calling.disabled = "0"
+function_calling.default = "0"
+function_calling.description = "Enable only when the selected AI service and model support tool use."
+
 -- max_tokens (ListValue), only for Anthropic and Custom Anthropic
 max_tokens = service:option(ListValue, "max_tokens", "Max Tokens")
 for i = 1000, 30000, 1000 do

--- a/oasis/files/usr/bin/oasis
+++ b/oasis/files/usr/bin/oasis
@@ -108,6 +108,7 @@ local options_spec = {
     ["-u"] = "u",
     ["-k"] = "k",
     ["-m"] = "m",
+    ["-f"] = "f",
     ["-s"] = "s"
 }
 
@@ -142,13 +143,14 @@ local function help()
         " -u <Endpoint>          Set the  AI Service Endpoint(URL)",
         " -k <api-key>           Set the API key",
         " -m <model>             Set the LLM model",
+        " -f <0|1>               Set Function Calling / Tool Use",
         " -p <storage>           Set the storage path",
         " -s <sysmsg key>        Select the system message key  (for sysmsg command)",
         " -c <system message>    Create new system message data (for sysmsg command)",
         "",
         "Commands:",
         " storage <path> [<chat-max>]",
-        " add [<service> [<endpoint> [<api-key> [<model> [<storage>]]]]]",
+        " add [<service> [<endpoint> [<api-key> [<model> [<function-calling>]]]]]",
         " change [no=<service-number> [<options> <value>]...]",
         " select [no=<service-number>]",
         " delete no=<service-number>",
@@ -248,6 +250,7 @@ commands.add = function(args)
         endpoint = args[3],
         api_key  = args[4],
         model    = args[5],
+        function_calling = args[6],
     })
 end
 

--- a/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
@@ -26,6 +26,7 @@ function M.get_ai_service_cfg(arg, opts)
     cfg.service    = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "name", "") or ""
     cfg.model      = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "model", "") or ""
     cfg.ipaddr     = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "ipaddr", "") or ""
+    cfg.function_calling = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "function_calling", "0") or "0"
 
     if opts and opts.with_storage then
         cfg.path   = uci:get(uci_ref.cfg, uci_ref.sect.storage, "path")

--- a/oasis/files/usr/lib/lua/oasis/chat/function/calling/anthropic.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/function/calling/anthropic.lua
@@ -49,7 +49,7 @@ function M.process(self, message)
     end
 
     local is_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-    if not is_tool then
+    if not (is_tool and common.check_function_calling_enabled(self)) then
         return nil
     end
 
@@ -179,7 +179,7 @@ end
 -- Inject tool definitions into the Anthropic request (beta tools schema)
 function M.inject_schema(self, body)
     local is_use_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-    if not is_use_tool then
+    if not (is_use_tool and common.check_function_calling_enabled(self)) then
         return body
     end
     if self and self.get_format and (self:get_format() == common.ai.format.title) then
@@ -252,4 +252,3 @@ function M.convert_tool_call(chat, speaker, msg)
 end
 
 return M
-

--- a/oasis/files/usr/lib/lua/oasis/chat/function/calling/gemini.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/function/calling/gemini.lua
@@ -54,7 +54,7 @@ function M.process(self, message)
 	end
 
 	local is_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-	if not is_tool then
+	if not (is_tool and common.check_function_calling_enabled(self)) then
 		return nil
 	end
 
@@ -157,7 +157,7 @@ end
 function M.inject_schema(self, user_msg)
 	-- Gemini attaches tools.functionDeclarations to the GenerateContent body.
 	local is_use_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-	if not is_use_tool then
+	if not (is_use_tool and common.check_function_calling_enabled(self)) then
 		return user_msg
 	end
 	if self and self.get_format and (self:get_format() == common.ai.format.title) then

--- a/oasis/files/usr/lib/lua/oasis/chat/function/calling/ollama.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/function/calling/ollama.lua
@@ -29,7 +29,7 @@ function M.process(self, message)
 	end
 
 	local is_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-	if not (is_tool and message and message.tool_calls) then
+	if not (is_tool and common.check_function_calling_enabled(self) and message and message.tool_calls) then
 		return nil
 	end
 
@@ -102,7 +102,7 @@ end
 
 function M.inject_schema(self, user_msg)
 	local is_use_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-	if not is_use_tool then
+	if not (is_use_tool and common.check_function_calling_enabled(self)) then
 		return user_msg
 	end
 	if self.get_format and (self:get_format() == common.ai.format.title) then

--- a/oasis/files/usr/lib/lua/oasis/chat/function/calling/openai.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/function/calling/openai.lua
@@ -29,7 +29,7 @@ function M.process(self, message)
 	end
 
 	local is_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-	if not (is_tool and message and message.tool_calls) then
+	if not (is_tool and common.check_function_calling_enabled(self) and message and message.tool_calls) then
 		return nil
 	end
 
@@ -102,7 +102,7 @@ end
 
 function M.inject_schema(self, user_msg)
 	local is_use_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-	if not is_use_tool then
+	if not (is_use_tool and common.check_function_calling_enabled(self)) then
 		return user_msg
 	end
 	if self.get_format and (self:get_format() == common.ai.format.title) then

--- a/oasis/files/usr/lib/lua/oasis/chat/main.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/main.lua
@@ -348,6 +348,28 @@ local function collect_model(args, output)
     end
 end
 
+local function normalize_function_calling(value, default)
+    if value == nil or value == "" then
+        return default
+    end
+
+    value = tostring(value):lower()
+
+    if value == "1" or value == "true" or value == "enable" or value == "enabled" then
+        return "1"
+    end
+
+    if value == "0" or value == "false" or value == "disable" or value == "disabled" then
+        return "0"
+    end
+
+    return nil
+end
+
+local function format_function_calling_status(value)
+    return (tostring(value or "0") == "1") and "enable" or "disable"
+end
+
 -- Determine endpoint field name
 local function determine_endpoint_field_name(service_name)
     return SERVICE_CONFIG.ENDPOINT_FIELDS[service_name] or "unknown"
@@ -363,6 +385,7 @@ local function create_uci_service_section(setup, endpoint_field_name)
     uci:set(common.db.uci.cfg, unnamed_section, endpoint_field_name, setup.endpoint)
     uci:set(common.db.uci.cfg, unnamed_section, "api_key", setup.api_key)
     uci:set(common.db.uci.cfg, unnamed_section, "model", setup.model)
+    uci:set(common.db.uci.cfg, unnamed_section, "function_calling", normalize_function_calling(setup.function_calling, "0") or "0")
 
     -- Endpoint type configuration
     local endpoint_type_field = SERVICE_CONFIG.ENDPOINT_TYPES[setup.service]
@@ -402,7 +425,8 @@ function M.add(args)
         service = collect_service_name(args, output),
         endpoint = collect_endpoint(args, output),
         api_key = collect_api_key(args, output),
-        model = collect_model(args, output)
+        model = collect_model(args, output),
+        function_calling = normalize_function_calling(args.function_calling, "0") or "0"
     }
 
     -- Collect Anthropic-specific configuration
@@ -477,6 +501,14 @@ local function update_service_config(service_section, opt)
         updated = true
     end
 
+    if opt.f then
+        local function_calling = normalize_function_calling(opt.f)
+        if function_calling then
+            uci:set(common.db.uci.cfg, service_section, "function_calling", function_calling)
+            updated = true
+        end
+    end
+
     if opt.s then
         uci:set(common.db.uci.cfg, service_section, "storage", opt.s)
         updated = true
@@ -516,7 +548,7 @@ end
 -- Main change function
 -- Change an existing AI service by numeric index with options.
 -- @param arg table { no: string }
--- @param opt table { u?: string, k?: string, m?: string, s?: string }
+-- @param opt table { u?: string, k?: string, m?: string, f?: string, s?: string }
 function M.change(arg, opt)
 
     local output = {
@@ -555,12 +587,15 @@ function M.show_service_list()
         console.print("-----------------------------------------------")
     end
 
+    output.label_width = 18
+    output.format_item = "%-" .. output.label_width .. "s >> \27[33m%s\27[0m\n"
+
     output.item = function(name, value)
         local display_value = value or "(not set)"
         if (name == "API KEY") and value then
-            console.printf("%-8s >> \27[33m%s\27[0m\n", name, "******************************")
+            console.printf(output.format_item, name, "******************************")
         else
-            console.printf("%-8s >> \27[33m%s\27[0m\n", name, display_value)
+            console.printf(output.format_item, name, display_value)
         end
         console.flush()
     end
@@ -608,6 +643,7 @@ function M.show_service_list()
 
             output.item("API KEY", tbl.api_key)
             output.item("MODEL", tbl.model)
+            output.item("Function Calling", format_function_calling_status(tbl.function_calling))
         end
     end)
 end
@@ -680,6 +716,8 @@ function M.select(arg)
         return
     end
 
+    local function_calling = format_function_calling_status(uci:get(common.db.uci.cfg, target_section, "function_calling"))
+
     -- swap section data
     uci:reorder(common.db.uci.cfg, target_section, 1)
     uci:commit(common.db.uci.cfg)
@@ -687,6 +725,7 @@ function M.select(arg)
     local model = uci:get_first(common.db.uci.cfg, common.db.uci.sect.service, "model")
     console.print("Service No: " .. arg.no .. " is selected.")
     console.print("Target model: \27[33m" .. model .. "\27[0m")
+    console.print("Function Calling: \27[33m" .. function_calling .. "\27[0m")
 end
 
 -- Initialize and display service information

--- a/oasis/files/usr/lib/lua/oasis/chat/service/ollama.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/service/ollama.lua
@@ -28,32 +28,6 @@ ollama.new = function()
             self.format = format
         end
 
-        local function is_model_tool_capable(model)
-            local name = tostring(model or ""):lower()
-            if #name == 0 then return false end
-            local markers = {
-                "llama3", "llama 3", -- llama3.x family
-                "qwen", "qwen2", "qwen3",
-                "mistral", "mixtral",
-                "deepseek",
-                "phi4", "phi-4",
-                "firefunction",
-                "gpt-oss",
-                "nemotron",
-                "granite",
-                "hermes",
-                "smollm",
-                "qwq",
-                "magistral",
-                "cogito",
-                "command-r"
-            }
-            for _, m in ipairs(markers) do
-                if name:find(m, 1, true) then return true end
-            end
-            return false
-        end
-
         obj.init_msg_buffer = function(self)
             self.recv_raw_msg.role = common.role.unknown
             self.recv_raw_msg.message = ""
@@ -85,7 +59,7 @@ ollama.new = function()
         -- [ADD] helper: execute tool calls when local_tool is enabled (return values and order preserved)
 		obj._process_tool_calls = function(self, message)
 			local is_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-			if not is_tool then
+			if not (is_tool and common.check_function_calling_enabled(self)) then
 				return nil
 			end
 
@@ -222,8 +196,6 @@ ollama.new = function()
 
         obj.convert_schema = function(self, user_msg)
             local is_use_tool = uci:get_bool(common.db.uci.cfg, common.db.uci.sect.support, "local_tool")
-            local model = (self.cfg and self.cfg.model) or ""
-            local supports_tool = is_model_tool_capable(model)
 
             -- When role:tool is present, it indicates that results are sent to AI
             -- Here we don't include the tools field (it's okay to include it, in which case tool execution can be done for failures)
@@ -236,7 +208,7 @@ ollama.new = function()
             end
 
             -- Inject tools schema for function calling (Ollama)
-            if is_use_tool and supports_tool and (self:get_format() ~= common.ai.format.title) then
+            if is_use_tool and common.check_function_calling_enabled(self) and (self:get_format() ~= common.ai.format.title) then
                 local client = require("oasis.local.tool.client")
                 local schema = client.get_function_call_schema()
 

--- a/oasis/files/usr/lib/lua/oasis/common.lua
+++ b/oasis/files/usr/lib/lua/oasis/common.lua
@@ -431,6 +431,32 @@ function M.check_prepare_oasis()
     return true
 end
 
+function M.check_function_calling_enabled(service)
+
+    local value = nil
+
+    if type(service) == "table" then
+        if type(service.get_config) == "function" then
+            local ok, cfg = pcall(function()
+                return service:get_config()
+            end)
+            if ok and type(cfg) == "table" then
+                value = cfg.function_calling
+            end
+        end
+
+        if value == nil then
+            value = service.function_calling
+        end
+    end
+
+    if value == nil then
+        value = uci:get_first(db.uci.cfg, db.uci.sect.service, "function_calling", "0")
+    end
+
+    return tostring(value or "0") == "1"
+end
+
 M.db = db
 M.ai = ai
 M.file = file


### PR DESCRIPTION
## Summary
Adds a per-service `function_calling` flag and disables function calling by default. This replaces the previous Ollama model-name allowlist so users can explicitly enable tool use for compatible models.

## Changes
  - Add `function_calling` config support
  - Add CLI `-f <0|1>` support
  - Show Function Calling status in `oasis select`
  - Add LuCI `Function Calling / Tool Use` flag
  - Remove Ollama model allowlist logic
  - Require `function_calling=1` before injecting or processing tool calls