### PR TITLE
Use timeout-aware ubus calls for title generation

### DIFF
--- a/oasis-mod-tool/files/usr/lib/lua/oasis/local/tool/client.lua
+++ b/oasis-mod-tool/files/usr/lib/lua/oasis/local/tool/client.lua
@@ -83,24 +83,7 @@ end
 
 local ubus_call = function(path, method, param, timeout)
 
-    local ubus = require("ubus")
-    local conn
-
-    if timeout and type(timeout) == "string" and #timeout > 0 then
-        conn = ubus.connect(nil, tonumber(timeout))
-    elseif timeout and type(timeout) == "number" and timeout > 0 then
-        conn = ubus.connect(nil, timeout)
-    else
-        -- default: 60s
-        conn = ubus.connect(nil, 60000)
-    end
-
-    if not conn then
-        return { error = "Failed to connect to ubus" }
-    end
-
-    local result, err = conn:call(path, method, param)
-    conn:close()
+    local result, err = common.ubus_call(path, method, param, timeout)
 
     if not result then
         return { error = err or "Failed to execute ubus call" }

--- a/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
@@ -13,6 +13,8 @@ local sysmsg_info = {}
 sysmsg_info.fix_key = {}
 sysmsg_info.fix_key.casual = "casual"
 
+local TITLE_AUTO_SET_TIMEOUT_MS = 120000
+
 function M.get_ai_service_cfg(arg, opts)
 
     debug:log("oasis.log", "get_ai_service_cfg", "\n--- [datactrl.lua][get_ai_service_cfg] ---")
@@ -158,7 +160,15 @@ function M.create_chat_file(service, chat)
 end
 
 function M.set_chat_title(service, chat_id)
-    local request = util.ubus("oasis.title", "auto_set", {id = chat_id})
+    -- Title generation calls the selected AI service through oasis.title and may
+    -- exceed the default ubus timeout on slow local LLMs. Use common.ubus_call()
+    -- so this long-running ubus request has an explicit timeout.
+    local request = common.ubus_call(
+        common.db.ubus.object.oasis_title,
+        common.db.ubus.method.auto_set,
+        {id = chat_id},
+        TITLE_AUTO_SET_TIMEOUT_MS
+    )
 
     if request.status == common.status.error then
         io.write("\n\27[1;33;41m Title Creation: Error \27[0m\n")

--- a/oasis/files/usr/lib/lua/oasis/chat/transfer.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/transfer.lua
@@ -6,12 +6,12 @@ local common    = require("oasis.common")
 local console   = require("oasis.console")
 local jsonc     = require("luci.jsonc")
 local datactrl  = require("oasis.chat.datactrl")
-local util      = require("luci.util")
 local ous       = require("oasis.unified.chat.schema")
 local misc      = require("oasis.chat.misc")
 local debug     = require("oasis.chat.debug")
 
 local M = {}
+local TITLE_AUTO_SET_TIMEOUT_MS = 120000
 
 -- Create a shallow copy of chat and drop transient messages before persisting
 -- - Exclude role=="tool"
@@ -244,7 +244,15 @@ function M.chat_with_ai(service, chat)
                     local save_chat = clone_chat_without_tool_messages(chat)
                     local chat_info = {}
                     chat_info.id = datactrl.create_chat_file(service, save_chat)
-                    local result = util.ubus("oasis.title", "auto_set", {id = chat_info.id}) or {}
+                    -- Title generation calls the selected AI service through oasis.title and may
+                    -- exceed the default ubus timeout on slow local LLMs. Use common.ubus_call()
+                    -- so this long-running ubus request has an explicit timeout.
+                    local result = common.ubus_call(
+                        common.db.ubus.object.oasis_title,
+                        common.db.ubus.method.auto_set,
+                        {id = chat_info.id},
+                        TITLE_AUTO_SET_TIMEOUT_MS
+                    ) or {}
                     chat_info.title = result.title or "--"
                     new_chat_info = jsonc.stringify(chat_info, false)
                     debug:log("oasis.log", "chat_with_ai", "new_chat_info = " .. new_chat_info)

--- a/oasis/files/usr/lib/lua/oasis/common.lua
+++ b/oasis/files/usr/lib/lua/oasis/common.lua
@@ -368,6 +368,38 @@ function M.check_chat_format(chat)
     return true
 end
 
+function M.ubus_call(object, method, data, timeout)
+
+    local conn
+
+    if timeout and type(timeout) == "string" and #timeout > 0 then
+        local timeout_ms = tonumber(timeout)
+        if timeout_ms and timeout_ms > 0 then
+            conn = ubus.connect(nil, timeout_ms)
+        end
+    elseif timeout and type(timeout) == "number" and timeout > 0 then
+        conn = ubus.connect(nil, timeout)
+    end
+
+    if not conn then
+        -- default: 60s
+        conn = ubus.connect(nil, 60000)
+    end
+
+    if not conn then
+        return nil, "Failed to connect to ubus"
+    end
+
+    local result, err = conn:call(object, method, data or {})
+    conn:close()
+
+    if not result then
+        return nil, err or "Failed to execute ubus call"
+    end
+
+    return result, nil
+end
+
 function M.check_server_loaded(server_name)
 
     -- timeout: 1000ms


### PR DESCRIPTION
## Changes

### Added a core timeout-aware ubus helper

Added `common.ubus_call()` in:

- `oasis/files/usr/lib/lua/oasis/common.lua`

The helper uses `ubus.connect(nil, timeout)` and supports an explicit timeout in milliseconds.

Behavior:

- Accepts `timeout` as a number or numeric string
- Uses `60000` milliseconds as the default timeout
- Returns `result, nil` on success
- Returns `nil, err` on failure
- Passes `{}` when the request payload is omitted

This provides a shared core implementation for ubus calls that may need custom timeout handling.

### Reused the core helper from `oasis-mod-tool`

Updated the local `ubus_call()` wrapper in:

- `oasis-mod-tool/files/usr/lib/lua/oasis/local/tool/client.lua`

The wrapper now calls `common.ubus_call()` internally while keeping the existing `oasis-mod-tool` behavior unchanged.

Compatibility behavior is preserved:

- Existing callers still call local `ubus_call(...)`
- Failure still returns `{ error = ... }`
- Tool execution code does not need to change

This avoids duplicating timeout-aware ubus connection logic between the core package and `oasis-mod-tool`.

### Switched automatic title generation to `common.ubus_call()`

Updated title generation call sites in:

- `oasis/files/usr/lib/lua/oasis/chat/datactrl.lua`
- `oasis/files/usr/lib/lua/oasis/chat/transfer.lua`

Both call sites now use:

```lua
common.ubus_call(
    common.db.ubus.object.oasis_title,
    common.db.ubus.method.auto_set,
    {id = chat_id},
    120000
)
```

The timeout is set to `120000` milliseconds, which is 120 seconds.

This matches the manual verification where the direct ubus call succeeded with:

```sh
ubus -t 120 call oasis.title auto_set '{"id":"7850508846"}'
```

### Added explanatory comments

Added comments near the title generation ubus calls explaining why `common.ubus_call()` is used:

```lua
-- Title generation calls the selected AI service through oasis.title and may
-- exceed the default ubus timeout on slow local LLMs. Use common.ubus_call()
-- so this long-running ubus request has an explicit timeout.
```

## Current Behavior

Automatic title generation now uses an explicit 120 second ubus timeout.

This should allow slow title generation requests to complete in cases where the default ubus timeout was too short.

The expected successful flow is:

1. The first chat response is generated.
2. Oasis creates a chat file.
3. Oasis calls `oasis.title auto_set` through `common.ubus_call()`.
4. The title generation request is allowed to run for up to 120 seconds.
5. If `oasis.title auto_set` returns successfully, the generated title is stored and displayed.