### PR TITLE
Feat/6 support uploading apk packages

### DIFF
--- a/dev_tools/oasis_build_and_upload
+++ b/dev_tools/oasis_build_and_upload
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REFRESH_SCRIPT_DIR="$(pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 # --------------------------------------------------------------------
 # Oasis Build & Upload Automation Script
@@ -19,6 +19,104 @@ REFRESH_SCRIPT_DIR="$(pwd)"
 #
 # If sshpass is missing, this script will tell you how to install it.
 # --------------------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+Usage:
+  oasis_build_and_upload [options]
+
+Options:
+  --reset                         Delete stored settings and exit.
+  --pkg-ext <ipk|apk>             Override package artifact extension for this run.
+  --package-format <ipk|apk>      Alias for --pkg-ext.
+  -h, --help                      Show this help.
+EOF
+}
+
+normalize_pkg_ext() {
+  local ext="${1:-}"
+  ext="${ext#.}"
+  ext="${ext,,}"
+
+  case "$ext" in
+    ipk|apk)
+      printf '%s\n' "$ext"
+      ;;
+    *)
+      echo "ERROR: package extension must be 'ipk' or 'apk'." >&2
+      return 1
+      ;;
+  esac
+}
+
+resolve_package_file() {
+  local name="$1"
+  local version="$2"
+  local ext="$3"
+  local patterns=()
+  local match
+
+  case "$ext" in
+    ipk)
+      patterns=(
+        "$BASE/${name}_${version}_all.${ext}"
+        "$BASE/${name}_${version}_*.${ext}"
+        "$BASE/${name}_*.${ext}"
+      )
+      ;;
+    apk)
+      patterns=(
+        "$BASE/${name}-${version}.${ext}"
+        "$BASE/${name}-${version}*.${ext}"
+        "$BASE/${name}-[0-9]*.${ext}"
+      )
+      ;;
+  esac
+
+  for pattern in "${patterns[@]}"; do
+    while IFS= read -r match; do
+      if [[ -f "$match" ]]; then
+        printf '%s\n' "$match"
+        return 0
+      fi
+    done < <(compgen -G "$pattern")
+  done
+
+  return 1
+}
+
+RESET_CONFIG=0
+PKG_EXT_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reset)
+      RESET_CONFIG=1
+      shift
+      ;;
+    --pkg-ext|--package-format)
+      if [[ -z "${2:-}" ]]; then
+        echo "ERROR: $1 requires a value: ipk or apk." >&2
+        exit 1
+      fi
+      PKG_EXT_OVERRIDE="$(normalize_pkg_ext "$2")"
+      shift 2
+      ;;
+    --pkg-ext=*|--package-format=*)
+      PKG_EXT_OVERRIDE="$(normalize_pkg_ext "${1#*=}")"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
 
 # ====================================
 # Check Required Commands
@@ -71,7 +169,7 @@ chmod 700 "$CONFIG_DIR"
 # ====================================
 # --reset option
 # ====================================
-if [[ "${1:-}" == "--reset" ]]; then
+if [[ "$RESET_CONFIG" == "1" ]]; then
   echo "Resetting stored settings..."
   rm -f "$CONFIG_FILE"
   echo "Done. Re-run the script to set up again."
@@ -89,11 +187,22 @@ fi
 source "$CONFIG_FILE"
 
 # ====================================
+# Package extension setup
+# ====================================
+if [[ -n "$PKG_EXT_OVERRIDE" ]]; then
+  PKG_EXT="$PKG_EXT_OVERRIDE"
+else
+  unset PKG_EXT
+  read -rp "Enter package extension for upload phase [ipk/apk] (default: ipk): " PKG_EXT
+  PKG_EXT="$(normalize_pkg_ext "${PKG_EXT:-ipk}")"
+fi
+
+# ====================================
 # BASE setup
 # ====================================
 if [[ -z "${BASE:-}" ]]; then
-  echo "You need to set the .ipk directory path (BASE)."
-  read -rp "Enter the path to the .ipk directory (BASE): " BASE
+  echo "You need to set the package artifact directory path (BASE)."
+  read -rp "Enter the path to the package artifact directory (BASE): " BASE
   echo "BASE=\"$BASE\"" >> "$CONFIG_FILE"
   echo "Saved BASE in config."
 fi
@@ -127,6 +236,7 @@ echo "--------------------------------------"
 echo "Target Host : $TARGET_IP"
 echo "Password    : (hidden)"
 echo "BASE Path   : $BASE"
+echo "Package Ext : .$PKG_EXT"
 echo "Config File : $CONFIG_FILE"
 echo "--------------------------------------"
 echo
@@ -157,32 +267,83 @@ make package/oasis-tool-maker/{clean,compile}
 make package/luci-i18n-oasis-ja/{clean,compile}
 
 # ====================================
-# Upload .ipk files
+# Upload package files
 # ====================================
-FILES=(
-  "oasis_${OASIS_VER}_all.ipk"
-  "luci-app-oasis_${LUCIOASIS_VER}_all.ipk"
-  "oasis-mod-tool_${TOOL_VER}_all.ipk"
-  "oasis-mod-agent_${AGENT_VER}_all.ipk"
-  "oasis-mod-retired_${RETIRED_VER}_all.ipk"
-  "oasis-tool-edge_${EDGE_VER}_all.ipk"
-  "oasis-mod-test_${TEST_VER}_all.ipk"
-  "oasis-tool-maker_${MAKER_VER}_all.ipk"
+PACKAGE_SPECS=(
+  "oasis:$OASIS_VER"
+  "luci-app-oasis:$LUCIOASIS_VER"
+  "oasis-mod-tool:$TOOL_VER"
+  "oasis-mod-agent:$AGENT_VER"
+  "oasis-mod-retired:$RETIRED_VER"
+  "oasis-tool-edge:$EDGE_VER"
+  "oasis-mod-test:$TEST_VER"
+  "oasis-tool-maker:$MAKER_VER"
 )
 
-for f in "${FILES[@]}"; do
-  src="$BASE/$f"
-  [[ -f "$src" ]] && sshpass -p "$SSH_PASS" scp "$src" "root@$TARGET_IP:/root/" || echo "Skipping missing file: $f"
+UPLOAD_FILES=()
+MISSING_PACKAGES=()
+
+for spec in "${PACKAGE_SPECS[@]}"; do
+  pkg_name="${spec%%:*}"
+  pkg_version="${spec#*:}"
+
+  if pkg_file="$(resolve_package_file "$pkg_name" "$pkg_version" "$PKG_EXT")"; then
+    UPLOAD_FILES+=("$pkg_file")
+  else
+    MISSING_PACKAGES+=("$pkg_name")
+  fi
+done
+
+if [[ "${#UPLOAD_FILES[@]}" == "0" ]]; then
+  echo "ERROR: No matching .${PKG_EXT} package files were found for upload."
+  echo "BASE Path   : $BASE"
+  echo "Package Ext : .$PKG_EXT"
+  echo
+  echo "Please check the following:"
+  echo "  - The selected package extension is correct for this build output."
+  echo "  - The target packages are selected under 'utakamo' in make menuconfig."
+  echo
+  echo "Expected package names:"
+  for spec in "${PACKAGE_SPECS[@]}"; do
+    echo "  ${spec%%:*}"
+  done
+  echo
+  echo "Available .${PKG_EXT} files:"
+  while IFS= read -r f; do
+    echo "  $f"
+  done < <(compgen -G "$BASE/*.${PKG_EXT}" || true)
+  exit 1
+fi
+
+if [[ "${#MISSING_PACKAGES[@]}" -gt 0 ]]; then
+  echo "Skipping missing .${PKG_EXT} packages:"
+  for pkg_name in "${MISSING_PACKAGES[@]}"; do
+    echo "  $pkg_name"
+  done
+  echo
+fi
+
+for src in "${UPLOAD_FILES[@]}"; do
+  sshpass -p "$SSH_PASS" scp "$src" "root@$TARGET_IP:/root/"
 done
 
 # ====================================
 # Upload oasis_reflesh_install script
 # ====================================
-REFRESH_SCRIPT="$REFRESH_SCRIPT_DIR/oasis_reflesh_install"
+case "$PKG_EXT" in
+  ipk)
+    REFRESH_SCRIPT="$SCRIPT_DIR/oasis_reflesh_install"
+    ;;
+  apk)
+    REFRESH_SCRIPT="$SCRIPT_DIR/oasis_reflesh_install_apk"
+    ;;
+esac
+
+REMOTE_REFRESH_SCRIPT="/root/oasis_reflesh_install"
 
 if [[ -f "$REFRESH_SCRIPT" ]]; then
-  echo "Uploading oasis_reflesh_install..."
-  sshpass -p "$SSH_PASS" scp "$REFRESH_SCRIPT" "root@$TARGET_IP:/root/"
+  echo "Uploading $(basename "$REFRESH_SCRIPT") as oasis_reflesh_install..."
+  sshpass -p "$SSH_PASS" scp "$REFRESH_SCRIPT" "root@$TARGET_IP:$REMOTE_REFRESH_SCRIPT"
   echo "✅ oasis_reflesh_install uploaded."
 else
   echo "⚠️ oasis_reflesh_install not found: $REFRESH_SCRIPT"

--- a/dev_tools/oasis_build_and_upload
+++ b/dev_tools/oasis_build_and_upload
@@ -328,25 +328,25 @@ for src in "${UPLOAD_FILES[@]}"; do
 done
 
 # ====================================
-# Upload oasis_reflesh_install script
+# Upload oasis_local_upgrade script
 # ====================================
 case "$PKG_EXT" in
   ipk)
-    REFRESH_SCRIPT="$SCRIPT_DIR/oasis_reflesh_install"
+    REFRESH_SCRIPT="$SCRIPT_DIR/oasis_local_upgrade"
     ;;
   apk)
-    REFRESH_SCRIPT="$SCRIPT_DIR/oasis_reflesh_install_apk"
+    REFRESH_SCRIPT="$SCRIPT_DIR/oasis_local_upgrade_apk"
     ;;
 esac
 
-REMOTE_REFRESH_SCRIPT="/root/oasis_reflesh_install"
+REMOTE_REFRESH_SCRIPT="/root/oasis_local_upgrade"
 
 if [[ -f "$REFRESH_SCRIPT" ]]; then
-  echo "Uploading $(basename "$REFRESH_SCRIPT") as oasis_reflesh_install..."
+  echo "Uploading $(basename "$REFRESH_SCRIPT") as oasis_local_upgrade..."
   sshpass -p "$SSH_PASS" scp "$REFRESH_SCRIPT" "root@$TARGET_IP:$REMOTE_REFRESH_SCRIPT"
-  echo "✅ oasis_reflesh_install uploaded."
+  echo "✅ oasis_local_upgrade uploaded."
 else
-  echo "⚠️ oasis_reflesh_install not found: $REFRESH_SCRIPT"
+  echo "⚠️ oasis_local_upgrade not found: $REFRESH_SCRIPT"
 fi
 
 echo
@@ -354,6 +354,6 @@ echo "✅ Upload complete."
 echo
 echo "To install on device:"
 echo "ssh root@$TARGET_IP"
-echo "root@OpenWrt:~# chmod +x oasis_reflesh_install"
-echo "root@OpenWrt:~# ./oasis_reflesh_install"
+echo "root@OpenWrt:~# chmod +x oasis_local_upgrade"
+echo "root@OpenWrt:~# ./oasis_local_upgrade"
 echo

--- a/dev_tools/oasis_local_upgrade
+++ b/dev_tools/oasis_local_upgrade
@@ -7,16 +7,16 @@
 #   This script removes old versions of Oasis packages, installs new ones,
 #   and restarts related services.
 #
-#   If you pass the keyword "migrate" as an argument, the script will:
+#   If you pass the keyword "keep-config" as an argument, the script will:
 #     1. Backup the current Oasis UCI configuration before removing packages.
 #     2. Restore the configuration after the new installation.
 #
 # Examples:
 #   oasis_local_upgrade
-#       -> Normal update (no data migration).
+#       -> Normal update.
 #
-#   oasis_local_upgrade migrate
-#       -> Update with data migration (backup + restore).
+#   oasis_local_upgrade keep-config
+#       -> Update while preserving the current Oasis configuration.
 #
 
 MODE="$1"
@@ -31,8 +31,8 @@ remove_if_installed() {
     fi
 }
 
-# Backup configuration if migrate mode is enabled
-if [ "$MODE" = "migrate" ]; then
+# Backup configuration if keep-config mode is enabled
+if [ "$MODE" = "keep-config" ]; then
     mkdir -p /tmp/oasis
     touch /tmp/oasis/backup
     uci export oasis > /tmp/oasis/backup
@@ -70,8 +70,8 @@ opkg install oasis-tool-edge_1.0.0-r1_all.ipk
 opkg install oasis-mod-test_1.0.0-r1_all.ipk
 opkg install oasis-tool-maker_1.0.0-r1_all.ipk
 
-# Restore configuration if migrate mode is enabled
-if [ "$MODE" = "migrate" ]; then
+# Restore configuration if keep-config mode is enabled
+if [ "$MODE" = "keep-config" ]; then
     uci -f /tmp/oasis/backup import oasis
     cp -r /tmp/oasis/oasis.conf /etc/oasis/oasis.conf
 fi

--- a/dev_tools/oasis_local_upgrade
+++ b/dev_tools/oasis_local_upgrade
@@ -1,63 +1,34 @@
 #!/bin/sh
 #
 # Usage:
-#    root@OpenWrt:~# oasis_reflesh_install [mode]
+#    root@OpenWrt:~# oasis_local_upgrade [mode]
 #
 # Description:
-#   This script removes old versions of Oasis packages, installs new APK
-#   packages, and restarts related services.
+#   This script removes old versions of Oasis packages, installs new ones,
+#   and restarts related services.
 #
 #   If you pass the keyword "migrate" as an argument, the script will:
 #     1. Backup the current Oasis UCI configuration before removing packages.
 #     2. Restore the configuration after the new installation.
 #
 # Examples:
-#   oasis_reflesh_install
+#   oasis_local_upgrade
 #       -> Normal update (no data migration).
 #
-#   oasis_reflesh_install migrate
+#   oasis_local_upgrade migrate
 #       -> Update with data migration (backup + restore).
 #
 
 MODE="$1"
 
 is_installed() {
-    apk info -e "$1" >/dev/null 2>&1
+    opkg status "$1" 2>/dev/null | grep -q "^Status: .* installed"
 }
 
 remove_if_installed() {
     if is_installed "$1"; then
-        apk del "$1"
+        opkg remove "$1"
     fi
-}
-
-find_apk() {
-    name="$1"
-    version="$2"
-
-    for pattern in "./${name}-${version}.apk" "./${name}-${version}"*.apk "./${name}-[0-9]"*.apk; do
-        for file in $pattern; do
-            if [ -f "$file" ]; then
-                echo "$file"
-                return 0
-            fi
-        done
-    done
-
-    return 1
-}
-
-install_apk() {
-    name="$1"
-    version="$2"
-    file="$(find_apk "$name" "$version")"
-
-    if [ -z "$file" ]; then
-        echo "ERROR: Missing APK package for $name"
-        exit 1
-    fi
-
-    apk add --allow-untrusted "$file"
 }
 
 # Backup configuration if migrate mode is enabled
@@ -67,6 +38,8 @@ if [ "$MODE" = "migrate" ]; then
     uci export oasis > /tmp/oasis/backup
     cp -r /etc/oasis/oasis.conf /tmp/oasis/oasis.conf
 fi
+
+opkg update
 
 # Remove tool plugins
 remove_if_installed oasis-tool-test
@@ -88,14 +61,14 @@ remove_if_installed oasis-mod-retired
 remove_if_installed oasis
 
 # Install new versions
-install_apk oasis 3.2.6-r1
-install_apk luci-app-oasis 3.2.6-r1
-install_apk oasis-mod-tool 1.1.1-r1
-install_apk oasis-mod-agent 1.0.0-r1
-install_apk oasis-mod-retired 1.0.0-r1
-install_apk oasis-tool-edge 1.0.0-r1
-install_apk oasis-mod-test 1.0.0-r1
-install_apk oasis-tool-maker 1.0.0-r1
+opkg install oasis_3.2.6-r1_all.ipk
+opkg install luci-app-oasis_3.2.6-r1_all.ipk
+opkg install oasis-mod-tool_1.1.1-r1_all.ipk
+opkg install oasis-mod-agent_1.0.0-r1_all.ipk
+opkg install oasis-mod-retired_1.0.0-r1_all.ipk
+opkg install oasis-tool-edge_1.0.0-r1_all.ipk
+opkg install oasis-mod-test_1.0.0-r1_all.ipk
+opkg install oasis-tool-maker_1.0.0-r1_all.ipk
 
 # Restore configuration if migrate mode is enabled
 if [ "$MODE" = "migrate" ]; then

--- a/dev_tools/oasis_local_upgrade_apk
+++ b/dev_tools/oasis_local_upgrade_apk
@@ -7,16 +7,16 @@
 #   This script removes old versions of Oasis packages, installs new APK
 #   packages, and restarts related services.
 #
-#   If you pass the keyword "migrate" as an argument, the script will:
+#   If you pass the keyword "keep-config" as an argument, the script will:
 #     1. Backup the current Oasis UCI configuration before removing packages.
 #     2. Restore the configuration after the new installation.
 #
 # Examples:
 #   oasis_local_upgrade
-#       -> Normal update (no data migration).
+#       -> Normal update.
 #
-#   oasis_local_upgrade migrate
-#       -> Update with data migration (backup + restore).
+#   oasis_local_upgrade keep-config
+#       -> Update while preserving the current Oasis configuration.
 #
 
 MODE="$1"
@@ -60,8 +60,8 @@ install_apk() {
     apk add --allow-untrusted "$file"
 }
 
-# Backup configuration if migrate mode is enabled
-if [ "$MODE" = "migrate" ]; then
+# Backup configuration if keep-config mode is enabled
+if [ "$MODE" = "keep-config" ]; then
     mkdir -p /tmp/oasis
     touch /tmp/oasis/backup
     uci export oasis > /tmp/oasis/backup
@@ -97,8 +97,8 @@ install_apk oasis-tool-edge 1.0.0-r1
 install_apk oasis-mod-test 1.0.0-r1
 install_apk oasis-tool-maker 1.0.0-r1
 
-# Restore configuration if migrate mode is enabled
-if [ "$MODE" = "migrate" ]; then
+# Restore configuration if keep-config mode is enabled
+if [ "$MODE" = "keep-config" ]; then
     uci -f /tmp/oasis/backup import oasis
     cp -r /tmp/oasis/oasis.conf /etc/oasis/oasis.conf
 fi

--- a/dev_tools/oasis_local_upgrade_apk
+++ b/dev_tools/oasis_local_upgrade_apk
@@ -1,34 +1,63 @@
 #!/bin/sh
 #
 # Usage:
-#    root@OpenWrt:~# oasis_reflesh_install [mode]
+#    root@OpenWrt:~# oasis_local_upgrade [mode]
 #
 # Description:
-#   This script removes old versions of Oasis packages, installs new ones,
-#   and restarts related services.
+#   This script removes old versions of Oasis packages, installs new APK
+#   packages, and restarts related services.
 #
 #   If you pass the keyword "migrate" as an argument, the script will:
 #     1. Backup the current Oasis UCI configuration before removing packages.
 #     2. Restore the configuration after the new installation.
 #
 # Examples:
-#   oasis_reflesh_install
+#   oasis_local_upgrade
 #       -> Normal update (no data migration).
 #
-#   oasis_reflesh_install migrate
+#   oasis_local_upgrade migrate
 #       -> Update with data migration (backup + restore).
 #
 
 MODE="$1"
 
 is_installed() {
-    opkg status "$1" 2>/dev/null | grep -q "^Status: .* installed"
+    apk info -e "$1" >/dev/null 2>&1
 }
 
 remove_if_installed() {
     if is_installed "$1"; then
-        opkg remove "$1"
+        apk del "$1"
     fi
+}
+
+find_apk() {
+    name="$1"
+    version="$2"
+
+    for pattern in "./${name}-${version}.apk" "./${name}-${version}"*.apk "./${name}-[0-9]"*.apk; do
+        for file in $pattern; do
+            if [ -f "$file" ]; then
+                echo "$file"
+                return 0
+            fi
+        done
+    done
+
+    return 1
+}
+
+install_apk() {
+    name="$1"
+    version="$2"
+    file="$(find_apk "$name" "$version")"
+
+    if [ -z "$file" ]; then
+        echo "ERROR: Missing APK package for $name"
+        exit 1
+    fi
+
+    apk add --allow-untrusted "$file"
 }
 
 # Backup configuration if migrate mode is enabled
@@ -38,8 +67,6 @@ if [ "$MODE" = "migrate" ]; then
     uci export oasis > /tmp/oasis/backup
     cp -r /etc/oasis/oasis.conf /tmp/oasis/oasis.conf
 fi
-
-opkg update
 
 # Remove tool plugins
 remove_if_installed oasis-tool-test
@@ -61,14 +88,14 @@ remove_if_installed oasis-mod-retired
 remove_if_installed oasis
 
 # Install new versions
-opkg install oasis_3.2.6-r1_all.ipk
-opkg install luci-app-oasis_3.2.6-r1_all.ipk
-opkg install oasis-mod-tool_1.1.1-r1_all.ipk
-opkg install oasis-mod-agent_1.0.0-r1_all.ipk
-opkg install oasis-mod-retired_1.0.0-r1_all.ipk
-opkg install oasis-tool-edge_1.0.0-r1_all.ipk
-opkg install oasis-mod-test_1.0.0-r1_all.ipk
-opkg install oasis-tool-maker_1.0.0-r1_all.ipk
+install_apk oasis 3.2.6-r1
+install_apk luci-app-oasis 3.2.6-r1
+install_apk oasis-mod-tool 1.1.1-r1
+install_apk oasis-mod-agent 1.0.0-r1
+install_apk oasis-mod-retired 1.0.0-r1
+install_apk oasis-tool-edge 1.0.0-r1
+install_apk oasis-mod-test 1.0.0-r1
+install_apk oasis-tool-maker 1.0.0-r1
 
 # Restore configuration if migrate mode is enabled
 if [ "$MODE" = "migrate" ]; then

--- a/dev_tools/oasis_reflesh_install_apk
+++ b/dev_tools/oasis_reflesh_install_apk
@@ -1,0 +1,108 @@
+#!/bin/sh
+#
+# Usage:
+#    root@OpenWrt:~# oasis_reflesh_install [mode]
+#
+# Description:
+#   This script removes old versions of Oasis packages, installs new APK
+#   packages, and restarts related services.
+#
+#   If you pass the keyword "migrate" as an argument, the script will:
+#     1. Backup the current Oasis UCI configuration before removing packages.
+#     2. Restore the configuration after the new installation.
+#
+# Examples:
+#   oasis_reflesh_install
+#       -> Normal update (no data migration).
+#
+#   oasis_reflesh_install migrate
+#       -> Update with data migration (backup + restore).
+#
+
+MODE="$1"
+
+is_installed() {
+    apk info -e "$1" >/dev/null 2>&1
+}
+
+remove_if_installed() {
+    if is_installed "$1"; then
+        apk del "$1"
+    fi
+}
+
+find_apk() {
+    name="$1"
+    version="$2"
+
+    for pattern in "./${name}-${version}.apk" "./${name}-${version}"*.apk "./${name}-[0-9]"*.apk; do
+        for file in $pattern; do
+            if [ -f "$file" ]; then
+                echo "$file"
+                return 0
+            fi
+        done
+    done
+
+    return 1
+}
+
+install_apk() {
+    name="$1"
+    version="$2"
+    file="$(find_apk "$name" "$version")"
+
+    if [ -z "$file" ]; then
+        echo "ERROR: Missing APK package for $name"
+        exit 1
+    fi
+
+    apk add --allow-untrusted "$file"
+}
+
+# Backup configuration if migrate mode is enabled
+if [ "$MODE" = "migrate" ]; then
+    mkdir -p /tmp/oasis
+    touch /tmp/oasis/backup
+    uci export oasis > /tmp/oasis/backup
+    cp -r /etc/oasis/oasis.conf /tmp/oasis/oasis.conf
+fi
+
+# Remove tool plugins
+remove_if_installed oasis-tool-test
+remove_if_installed oasis-tool-wireguard
+
+# Remove old versions
+remove_if_installed luci-i18n-oasis-ja
+remove_if_installed oasis-tool-analysis
+remove_if_installed oasis-tool-template
+remove_if_installed oasis-tool-wireguard
+remove_if_installed oasis-tool-test
+remove_if_installed oasis-tool-edge
+remove_if_installed oasis-tool-maker
+remove_if_installed luci-app-oasis
+remove_if_installed oasis-mod-test
+remove_if_installed oasis-mod-agent
+remove_if_installed oasis-mod-tool
+remove_if_installed oasis-mod-retired
+remove_if_installed oasis
+
+# Install new versions
+install_apk oasis 3.2.6-r1
+install_apk luci-app-oasis 3.2.6-r1
+install_apk oasis-mod-tool 1.1.1-r1
+install_apk oasis-mod-agent 1.0.0-r1
+install_apk oasis-mod-retired 1.0.0-r1
+install_apk oasis-tool-edge 1.0.0-r1
+install_apk oasis-mod-test 1.0.0-r1
+install_apk oasis-tool-maker 1.0.0-r1
+
+# Restore configuration if migrate mode is enabled
+if [ "$MODE" = "migrate" ]; then
+    uci -f /tmp/oasis/backup import oasis
+    cp -r /tmp/oasis/oasis.conf /etc/oasis/oasis.conf
+fi
+
+# Restart services
+service olt_tool restart
+service rpcd restart


### PR DESCRIPTION
## Implementation Note

Implemented `.apk` upload support for `dev_tools/oasis_build_and_upload`.

The original issue focused on resolving upload artifacts by package extension instead of hardcoded `.ipk` filenames. During
implementation, the device-side upgrade helper was also updated so the uploaded `.apk` packages can be installed with the same
workflow after upload.

### Changes

- Added support for selecting the upload package format:
  - `.ipk`
  - `.apk`
- Added CLI options:
  - `--pkg-ext ipk|apk`
  - `--package-format ipk|apk`
- Kept the OpenWrt build commands unchanged.
- Changed the upload phase to resolve package artifacts by package name and selected extension instead of hardcoded `.ipk`
filenames.
- Added support for APK-style filenames such as:
  - `oasis-3.2.6-r1.apk`
  - `oasis-mod-tool-1.1.1-r1.apk`
- Improved the error message when no matching package files are found.
  - It now suggests checking the selected package extension.
  - It also suggests checking whether the target packages are enabled under `utakamo` in `make menuconfig`.
- Fixed install-helper path resolution so it is based on the script directory, not the current working directory.
- Added an APK-compatible device-side upgrade helper.
- Renamed the device-side upgrade helper to:
  - `/root/oasis_local_upgrade`

### Device-side upgrade helper

The original issue only targeted the upload phase, but uploading `.apk` packages alone was not enough because the existing device-side helper was `opkg`/`.ipk` specific.

To keep the post-upload workflow usable for both formats, the helper selected for upload now depends on the selected package
format:

- `ipk` uses `dev_tools/oasis_local_upgrade`
- `apk` uses `dev_tools/oasis_local_upgrade_apk`

Both are uploaded as:

```sh
/root/oasis_local_upgrade
```

The configuration-preserving mode is now:

```sh
./oasis_local_upgrade keep-config
```

This replaces the previous migrate mode name and better describes the behavior.

### Notes
It does not change OpenWrt package definitions or Oasis runtime behavior.