### PR TITLE
Improve chat error reporting diagnostics

### DIFF
--- a/luci-app-oasis/files/luci/www/luci-static/resources/oasis/css/chat.css
+++ b/luci-app-oasis/files/luci/www/luci-static/resources/oasis/css/chat.css
@@ -1008,6 +1008,7 @@ textarea:focus-visible {
     border: 1px solid #ffb3b3;
     color: #8a1f1f;
     font-weight: 600;
+    white-space: pre-wrap;
 }
 .message .message-text .error-notice::before {
     content: "⚠ ";

--- a/luci-app-oasis/files/luci/www/luci-static/resources/oasis/js/chat.js
+++ b/luci-app-oasis/files/luci/www/luci-static/resources/oasis/js/chat.js
@@ -40,6 +40,34 @@
         return result;
     }
 
+    function formatChatError(error) {
+        if (!error) {
+            return t('noResponse', 'No response from AI service. Please check settings.');
+        }
+
+        if (typeof error === 'string') {
+            return error;
+        }
+
+        if (typeof error.display === 'string' && error.display.length > 0) {
+            return error.display;
+        }
+
+        const lines = [];
+        lines.push(error.message || 'Chat request failed.');
+        if (error.phase) lines.push(`Phase: ${error.phase}`);
+        if (error.service) lines.push(`AI Service: ${error.service}`);
+        if (error.model) lines.push(`Model: ${error.model}`);
+        if (error.kind) lines.push(`Type: ${error.kind}`);
+        if (error.provider_message) lines.push(`Provider: ${error.provider_message}`);
+        if (error.detail) lines.push(`Detail: ${error.detail}`);
+        if (Object.prototype.hasOwnProperty.call(error, 'can_continue')) {
+            lines.push(`Chat can continue: ${error.can_continue ? 'yes' : 'no'}`);
+        }
+
+        return lines.join('\n');
+    }
+
     const utils = window.OasisChatUtils || {};
     const convertMarkdownToHTML = utils.convertMarkdownToHTML || (v => String(v || ''));
     const sanitizeHTML = utils.sanitizeHTML || (v => String(v || ''));
@@ -2125,6 +2153,10 @@
         let shutdownRequired = false;
         let pendingServiceRestart = '';
 
+        function appendErrorNotice(error) {
+            errorNoticesHtml += `<div class="error-notice">${escapeHTML(formatChatError(error))}</div>`;
+        }
+
         try {
             const response = await fetch(`${baseUrl}/cgi-bin/oasis`, {
                 method: 'POST',
@@ -2171,6 +2203,16 @@
                     if (evt && evt.reboot === true) { rebootRequired = true }
                     if (evt && evt.shutdown === true) { shutdownRequired = true }
                     if (evt && evt.shutdown === true) { shutdownRequired = true }
+
+                    if (evt && evt.error) {
+                        await hideDownloadOverlayAndWait();
+                        appendErrorNotice(evt.error);
+                        continue;
+                    }
+
+                    if (evt && evt.warning) {
+                        appendErrorNotice(evt.warning);
+                    }
 
                     // Custom stream events: execution/download
                     if (evt && typeof evt.type === 'string') {
@@ -2370,6 +2412,15 @@
                     //console.log('[AI single evt]', evt);
 
                     if (evt && evt.reboot === true) { rebootRequired = true }
+
+                    if (evt && evt.error) {
+                        await hideDownloadOverlayAndWait();
+                        appendErrorNotice(evt.error);
+                    }
+
+                    if (evt && evt.warning) {
+                        appendErrorNotice(evt.warning);
+                    }
 
                     // Tool execution notice (single JSON)
                     if (evt && Array.isArray(evt.tool_outputs)) {

--- a/oasis/Makefile
+++ b/oasis/Makefile
@@ -67,6 +67,7 @@ define Package/oasis/install
 	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/chat/misc.lua $(1)$(LUA_LIBRARY_DIR)/oasis/chat
 	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/chat/markdown.lua $(1)$(LUA_LIBRARY_DIR)/oasis/chat
 	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/chat/debug.lua $(1)$(LUA_LIBRARY_DIR)/oasis/chat
+	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/chat/error.lua $(1)$(LUA_LIBRARY_DIR)/oasis/chat
 	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/unified/chat/schema.lua $(1)$(LUA_LIBRARY_DIR)/oasis/unified/chat
 	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/security/guard.lua $(1)$(LUA_LIBRARY_DIR)/oasis/security
 	$(INSTALL_BIN) ./files/usr/lib/lua/oasis/chat/function/calling/ollama.lua $(1)$(LUA_LIBRARY_DIR)/oasis/chat/function/calling

--- a/oasis/files/luci/www/cgi-bin/oasis
+++ b/oasis/files/luci/www/cgi-bin/oasis
@@ -5,6 +5,7 @@ local uci   = require("luci.model.uci").cursor()
 local common= require("oasis.common")
 local oasis = require("oasis.chat.main")
 local debug = require("oasis.chat.debug")
+local chat_error = require("oasis.chat.error")
 
 -- HTTP request validation
 local function validate_request()
@@ -41,12 +42,32 @@ end
 local function process_ai_response(json_tbl)
     debug:log("oasis.log", "process_ai_response", "call oasis.output")
 
-    -- Call directly without pcall; rely on return values to detect failure
-    local new_chat_info, plain_text_ai_message = oasis.output(json_tbl)
+    local ok, new_chat_info, plain_text_ai_message, err = pcall(function()
+        return oasis.output(json_tbl)
+    end)
+
+    if not ok then
+        return nil, nil, chat_error.build(nil, {
+            phase = "internal",
+            kind = "internal_error",
+            message = "Chat processing failed.",
+            detail = tostring(new_chat_info),
+            can_continue = false,
+        })
+    end
+
+    if err then
+        return nil, nil, err
+    end
 
     -- If both are nil, treat as internal error (handled by caller)
     if (not new_chat_info) and (not plain_text_ai_message) then
-        return nil, nil, "Internal error: oasis.output failed"
+        return nil, nil, chat_error.build(nil, {
+            phase = "internal",
+            kind = "internal_error",
+            message = "Chat processing failed.",
+            detail = "oasis.output returned no response",
+        })
     end
 
     debug:log("oasis.log", "process_ai_response", "oasis.output returned: new_chat_info_len=" .. tostring((new_chat_info and #new_chat_info) or 0)
@@ -116,23 +137,31 @@ local function main()
     -- Validate request
     local content_length, error_msg = validate_request()
     if not content_length then
-        io.write(error_msg)
+        io.write(chat_error.to_json(chat_error.build(nil, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = error_msg,
+        })))
         return
     end
 
     -- Parse POST data
     local json_tbl, error_msg = parse_post_data(content_length)
     if not json_tbl then
-        io.write(error_msg)
-    debug:log("oasis.log", "main", "json parse error")
+        io.write(chat_error.to_json(chat_error.build(nil, {
+            phase = "request_creation",
+            kind = "parse_error",
+            message = "Failed to parse WebUI chat request.",
+            detail = error_msg,
+        })))
+        debug:log("oasis.log", "main", "json parse error")
         return
     end
 
     -- Process AI response
-    local new_chat_info, plain_text_ai_message, error_msg = process_ai_response(json_tbl)
+    local new_chat_info, plain_text_ai_message, err = process_ai_response(json_tbl)
     if not new_chat_info and not plain_text_ai_message then
-        local fallback = jsonc.stringify({ message = { role = "assistant", content = error_msg } }, false)
-        io.write(fallback)
+        io.write(chat_error.to_json(err))
         io.flush()
         return
     end

--- a/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
@@ -6,6 +6,7 @@ local common    = require("oasis.common")
 local misc      = require("oasis.chat.misc")
 local ous       = require("oasis.unified.chat.schema")
 local debug     = require("oasis.chat.debug")
+local chat_error = require("oasis.chat.error")
 
 local M = {}
 
@@ -160,22 +161,32 @@ function M.create_chat_file(service, chat)
 end
 
 function M.set_chat_title(service, chat_id)
+    service:set_chat_id(chat_id)
+
     -- Title generation calls the selected AI service through oasis.title and may
     -- exceed the default ubus timeout on slow local LLMs. Use common.ubus_call()
     -- so this long-running ubus request has an explicit timeout.
-    local request = common.ubus_call(
+    local request, err = common.ubus_call(
         common.db.ubus.object.oasis_title,
         common.db.ubus.method.auto_set,
         {id = chat_id},
         TITLE_AUTO_SET_TIMEOUT_MS
     )
 
-    if request.status == common.status.error then
+    if (not request) or err or request.status == common.status.error then
+        local title_err = chat_error.build(service, {
+            phase = "title_generation",
+            kind = "title_error",
+            message = "Chat title generation failed.",
+            provider_message = err or request and request.desc,
+            can_continue = true,
+        })
+        debug:log("oasis.log", "set_chat_title", chat_error.format(title_err))
         io.write("\n\27[1;33;41m Title Creation: Error \27[0m\n")
+        io.write(chat_error.format(title_err) .. "\n")
+        io.flush()
         return
     end
-
-    service:set_chat_id(chat_id)
 
     local announce =  "\n" .. "\27[1;37;44m" .. "Title:"
     announce = announce  .. "\27[1;33;44m" .. request.title

--- a/oasis/files/usr/lib/lua/oasis/chat/error.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/error.lua
@@ -1,0 +1,184 @@
+#!/usr/bin/env lua
+
+local jsonc  = require("luci.jsonc")
+local common = require("oasis.common")
+
+local M = {}
+
+local phase_label = {
+    request_creation = "Request creation",
+    http_request = "HTTP communication",
+    api_response = "AI service response",
+    response_parse = "Response parsing",
+    function_calling = "Function Calling",
+    tool_execution = "Tool execution",
+    title_generation = "Title generation",
+    internal = "Internal processing",
+}
+
+local kind_label = {
+    request_error = "request error",
+    connection_error = "connection error",
+    timeout = "timeout",
+    api_error = "API error",
+    parse_error = "parse error",
+    unsupported_feature = "unsupported feature",
+    tool_error = "tool error",
+    title_error = "title generation error",
+    internal_error = "internal error",
+    empty_response = "empty response",
+}
+
+local function non_empty(value)
+    value = tostring(value or "")
+    if #value == 0 then
+        return nil
+    end
+    return value
+end
+
+local function get_service_cfg(service)
+    if type(service) ~= "table" or type(service.get_config) ~= "function" then
+        return {}
+    end
+
+    local ok, cfg = pcall(function()
+        return service:get_config()
+    end)
+
+    if ok and type(cfg) == "table" then
+        return cfg
+    end
+
+    return {}
+end
+
+function M.classify_provider_message(message)
+    local lower = tostring(message or ""):lower()
+
+    if lower:match("timeout") or lower:match("timed out") then
+        return "timeout"
+    end
+
+    if lower:match("does not support tools")
+        or lower:match("unsupported.*tool")
+        or lower:match("tool.*unsupported")
+        or lower:match("not support.*tool") then
+        return "unsupported_feature"
+    end
+
+    if lower:match("connection")
+        or lower:match("could not resolve")
+        or lower:match("connection refused")
+        or lower:match("failed to connect") then
+        return "connection_error"
+    end
+
+    return "api_error"
+end
+
+function M.build(service, opts)
+    opts = opts or {}
+    local cfg = get_service_cfg(service)
+    local provider_message = non_empty(opts.provider_message)
+    local detail = non_empty(opts.detail)
+    local message = non_empty(opts.message)
+
+    if not message then
+        message = provider_message or detail or "Chat request failed."
+    end
+
+    local err = {
+        status = common.status.error,
+        phase = opts.phase or "internal",
+        kind = opts.kind or "internal_error",
+        message = message,
+        provider_message = provider_message,
+        detail = detail,
+        service = non_empty(opts.service) or non_empty(cfg.service) or "unknown",
+        model = non_empty(opts.model) or non_empty(cfg.model) or "unknown",
+        can_continue = (opts.can_continue ~= false),
+    }
+
+    err.display = M.format(err)
+
+    return err
+end
+
+function M.api_error(service, provider_message, opts)
+    opts = opts or {}
+    local kind = opts.kind or M.classify_provider_message(provider_message)
+    local message = opts.message
+
+    if not message then
+        if kind == "unsupported_feature" then
+            message = "AI service rejected Function Calling or tool use."
+        else
+            message = "AI service returned an error."
+        end
+    end
+
+    return M.build(service, {
+        phase = opts.phase or "api_response",
+        kind = kind,
+        message = message,
+        provider_message = provider_message,
+        detail = opts.detail,
+        can_continue = opts.can_continue,
+    })
+end
+
+function M.format(err)
+    if type(err) ~= "table" then
+        return tostring(err or "Chat request failed.")
+    end
+
+    local lines = {}
+    lines[#lines + 1] = tostring(err.message or "Chat request failed.")
+    lines[#lines + 1] = "Phase: " .. tostring(phase_label[err.phase] or err.phase or "unknown")
+    lines[#lines + 1] = "AI Service: " .. tostring(err.service or "unknown")
+    lines[#lines + 1] = "Model: " .. tostring(err.model or "unknown")
+    lines[#lines + 1] = "Type: " .. tostring(kind_label[err.kind] or err.kind or "unknown")
+
+    if err.provider_message and #tostring(err.provider_message) > 0 then
+        lines[#lines + 1] = "Provider: " .. tostring(err.provider_message)
+    end
+
+    if err.detail and #tostring(err.detail) > 0 then
+        lines[#lines + 1] = "Detail: " .. tostring(err.detail)
+    end
+
+    lines[#lines + 1] = "Chat can continue: " .. ((err.can_continue ~= false) and "yes" or "no")
+
+    return table.concat(lines, "\n")
+end
+
+function M.to_response(err)
+    if type(err) ~= "table" then
+        err = M.build(nil, { message = tostring(err or "Chat request failed.") })
+    end
+
+    if not err.display then
+        err.display = M.format(err)
+    end
+
+    return { error = err }
+end
+
+function M.to_json(err)
+    return jsonc.stringify(M.to_response(err), false)
+end
+
+function M.to_status(err)
+    if type(err) ~= "table" then
+        err = M.build(nil, { message = tostring(err or "Chat request failed.") })
+    end
+
+    return {
+        status = common.status.error,
+        desc = err.display or M.format(err),
+        error = err,
+    }
+end
+
+return M

--- a/oasis/files/usr/lib/lua/oasis/chat/main.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/main.lua
@@ -11,6 +11,7 @@ local common            = require("oasis.common")
 local console           = require("oasis.console")
 local ous               = require("oasis.unified.chat.schema")
 local debug             = require("oasis.chat.debug")
+local chat_error        = require("oasis.chat.error")
 
 local M = {}
 
@@ -879,7 +880,11 @@ local function process_message(service, chat, message)
 
     datactrl.record_chat_data(service, chat)
 
-    local tool_info, _, tool_used = transfer.chat_with_ai(service, chat)
+    local tool_info, _, tool_used, err = transfer.chat_with_ai(service, chat)
+
+    if err then
+        return false, chat_error.format(err)
+    end
 
     debug:log("oasis.log", "process_message", "tool_used = " .. tostring(tool_used))
     debug:log("oasis.log", "process_message", "tool_info = " .. tostring(tool_info))
@@ -889,9 +894,16 @@ local function process_message(service, chat, message)
 
     if tool_used then
         if service:handle_tool_output(tool_info, chat) then
-            transfer.chat_with_ai(service, chat)
+            local _, _, _, post_err = transfer.chat_with_ai(service, chat)
+            if post_err then
+                return false, chat_error.format(post_err)
+            end
         else
-            return false, "failed to handle tool output"
+            return false, chat_error.format(chat_error.build(service, {
+                phase = "tool_execution",
+                kind = "tool_error",
+                message = "Failed to handle tool output.",
+            }))
         end
     end
 
@@ -1031,8 +1043,13 @@ function M.prompt(arg)
         return false
     end
 
-    local tool_info, _, tool_used = transfer.chat_with_ai(service, prompt)
+    local tool_info, _, tool_used, err = transfer.chat_with_ai(service, prompt)
     console.print()
+
+    if err then
+        console.print("\27[31m" .. chat_error.format(err) .. "\27[0m")
+        return
+    end
 
     debug:log("oasis.log", "prompt", "tool_used = " .. tostring(tool_used))
     debug:log("oasis.log", "prompt", "tool_info = " .. tostring(tool_info))
@@ -1042,8 +1059,17 @@ function M.prompt(arg)
 
     if tool_used then
         if service:handle_tool_output(tool_info, prompt) then
-            transfer.chat_with_ai(service, prompt)
+            local _, _, _, post_err = transfer.chat_with_ai(service, prompt)
+            if post_err then
+                console.print("\27[31m" .. chat_error.format(post_err) .. "\27[0m")
+            end
             print()
+        else
+            console.print("\27[31m" .. chat_error.format(chat_error.build(service, {
+                phase = "tool_execution",
+                kind = "tool_error",
+                message = "Failed to handle tool output.",
+            })) .. "\27[0m")
         end
     end
 
@@ -1178,24 +1204,35 @@ end
 local function process_output_message(service, chat_ctx, message)
 
     if not ous.setup_msg(service, chat_ctx, { role = common.role.user, message = message }) then
-        return nil, nil
+        return nil, nil, chat_error.build(service, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = "Failed to prepare user message.",
+        })
     end
 
     -- chat_with_ai returns: new_chat_info (or tool JSON when tool_used), plain_text_message, tool_used
-    local new_chat_info, plain_text_message, tool_used = transfer.chat_with_ai(service, chat_ctx)
+    local new_chat_info, plain_text_message, tool_used, err = transfer.chat_with_ai(service, chat_ctx)
+    if err then
+        return nil, nil, err
+    end
 
     if tool_used then
         -- Provide tool outputs back to the model, then get assistant's text reply
         if service:handle_tool_output(new_chat_info, chat_ctx) then
-            local post_new_chat_info, post_message = transfer.chat_with_ai(service, chat_ctx)
-            return post_new_chat_info, post_message
+            local post_new_chat_info, post_message, _, post_err = transfer.chat_with_ai(service, chat_ctx)
+            return post_new_chat_info, post_message, post_err
         else
-            return nil, nil
+            return nil, nil, chat_error.build(service, {
+                phase = "tool_execution",
+                kind = "tool_error",
+                message = "Failed to handle tool output.",
+            })
         end
     end
 
     -- No tools used: return values as-is
-    return new_chat_info, plain_text_message
+    return new_chat_info, plain_text_message, nil
 end
 
 -- Main output function
@@ -1207,7 +1244,12 @@ function M.output(arg)
 
     local service = initialize_output_service(arg)
     if not service then
-        return nil, nil
+        return nil, nil, chat_error.build(nil, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = "AI service configuration was not found.",
+            can_continue = false,
+        })
     end
 
     clear_flg()
@@ -1218,7 +1260,11 @@ function M.output(arg)
     debug:log("oasis.log", "output", "Load chat data ...")
     -- debug:dump("oasis.log", chat_ctx)
 
-    local new_chat_info, plain_text_ai_message = process_output_message(service, chat_ctx, arg.message)
+    local new_chat_info, plain_text_ai_message, err = process_output_message(service, chat_ctx, arg.message)
+    if err then
+        debug:log("oasis.log", "output", chat_error.format(err))
+        return nil, nil, err
+    end
     -- Log returned values for diagnostics
     debug:log("oasis.log", "output", "returned new_chat_info_len=" .. tostring((new_chat_info and #new_chat_info) or 0)
         .. ", message_len=" .. tostring((plain_text_ai_message and #plain_text_ai_message) or 0))
@@ -1231,7 +1277,7 @@ function M.output(arg)
         debug:log("oasis.log", "output", "message=" .. tostring(plain_text_ai_message))
     end
 
-    return new_chat_info, plain_text_ai_message
+    return new_chat_info, plain_text_ai_message, nil
 end
 
 -- RPC output mode for ubus: returns (status_tbl, new_chat_info, message, reboot).
@@ -1256,7 +1302,12 @@ function M.rpc_output(arg)
     clear_flg()
 
     if not service then
-        return { status = common.status.error, desc = "AI Service Not Found." }, nil, nil
+        return chat_error.to_status(chat_error.build(nil, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = "AI service configuration was not found.",
+            can_continue = false,
+        })), nil, nil
     end
 
     service:initialize(arg, common.ai.format.rpc_output)
@@ -1279,7 +1330,10 @@ function M.rpc_output(arg)
         debug:log("oasis.log", "rpc_output", "[main.lua][rpc_output] record_chat_data done ...")
 
         -- First call
-        local first, plain_text, tool_used = transfer.chat_with_ai(service, chat_ctx)
+        local first, plain_text, tool_used, err = transfer.chat_with_ai(service, chat_ctx)
+        if err then
+            return chat_error.to_status(err), nil, nil
+        end
 
         if tool_used then
             -- Keep tool JSON for external device
@@ -1287,10 +1341,17 @@ function M.rpc_output(arg)
             -- Provide tool outputs back to model
             if service:handle_tool_output(tool_info, chat_ctx) then
                 -- Second call to get assistant text (and possibly new chat info)
-                local post_new_chat_info, post_message = transfer.chat_with_ai(service, chat_ctx)
+                local post_new_chat_info, post_message, _, post_err = transfer.chat_with_ai(service, chat_ctx)
+                if post_err then
+                    return chat_error.to_status(post_err), nil, nil
+                end
                 new_chat_info, message = post_new_chat_info, post_message
             else
-                return { status = common.status.error, desc = "failed to handle tool output" }, nil, nil
+                return chat_error.to_status(chat_error.build(service, {
+                    phase = "tool_execution",
+                    kind = "tool_error",
+                    message = "Failed to handle tool output.",
+                })), nil, nil
             end
         else
             -- No tools used
@@ -1298,6 +1359,12 @@ function M.rpc_output(arg)
         end
 
         debug:log("oasis.log", "rpc_output", "[main.lua][rpc_output] chat_with_ai done ...")
+    else
+        return chat_error.to_status(chat_error.build(service, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = "Failed to prepare user message.",
+        })), nil, nil
     end
 
     if new_chat_info then

--- a/oasis/files/usr/lib/lua/oasis/chat/service/anthropic.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/service/anthropic.lua
@@ -9,6 +9,7 @@ local misc      = require("oasis.chat.misc")
 local ous       = require("oasis.unified.chat.schema")
 local debug     = require("oasis.chat.debug")
 local calling   = require("oasis.chat.function.calling.anthropic")
+local chat_error = require("oasis.chat.error")
 
 local anthropic = {}
 anthropic.new = function()
@@ -169,12 +170,9 @@ anthropic.new = function()
             -- API error handling
             if chunk_json.error and chunk_json.error.message then
                 local msg = tostring(chunk_json.error.message)
+                local detail = chunk_json.error.type or chunk_json.error.code
                 self.chunk_all = ""
-                self.recv_raw_msg.role = common.role.assistant
-                self.recv_raw_msg.message = msg
-                local plain_text_for_console = misc.markdown(self.mark, msg)
-                local response_ai_json = jsonc.stringify({ message = { role = common.role.assistant, content = msg } }, false)
-                return plain_text_for_console, response_ai_json, self.recv_raw_msg, false
+                return nil, nil, self.recv_raw_msg, false, chat_error.api_error(self, msg, { detail = detail })
             end
 
             -- Tool call detection and processing (Anthropic tool_use)

--- a/oasis/files/usr/lib/lua/oasis/chat/service/gemini.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/service/gemini.lua
@@ -9,6 +9,7 @@ local misc      = require("oasis.chat.misc")
 local debug     = require("oasis.chat.debug")
 local ous      = require("oasis.unified.chat.schema")
 local calling   = require("oasis.chat.function.calling.gemini")
+local chat_error = require("oasis.chat.error")
 
 local gemini ={}
 gemini.new = function()
@@ -192,17 +193,9 @@ gemini.new = function()
 
             if chunk_json.error and (chunk_json.error.message) then
                 local msg = tostring(chunk_json.error.message)
+                local detail = chunk_json.error.status or chunk_json.error.code
                 debug:log("oasis.log", "gemini.recv_ai_msg", "api_error=" .. msg)
-                self.recv_raw_msg.role = common.role.assistant
-                self.recv_raw_msg.message = msg
-                local plain_text_for_console = misc.markdown(self.mark, msg)
-                local response_ai_json = jsonc.stringify({
-                    message = {
-                        role = common.role.assistant,
-                        content = msg
-                    }
-                }, false)
-                return plain_text_for_console, response_ai_json, self.recv_raw_msg, false
+                return nil, nil, self.recv_raw_msg, false, chat_error.api_error(self, msg, { detail = detail })
             end
 
             -- Detect functionCall via calling module ---> execute local tool and return tool_used

--- a/oasis/files/usr/lib/lua/oasis/chat/service/ollama.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/service/ollama.lua
@@ -9,6 +9,7 @@ local misc      = require("oasis.chat.misc")
 local debug     = require("oasis.chat.debug")
 local calling   = require("oasis.chat.function.calling.ollama")
 local ous       = require("oasis.unified.chat.schema")
+local chat_error = require("oasis.chat.error")
 
 local ollama ={}
 ollama.new = function()
@@ -47,11 +48,21 @@ ollama.new = function()
 		end
 
         -- [ADD] helper: detect presence of tool_calls (returns message if present)
-		obj._has_tool_calls = function(self, chunk_json)
+        obj._has_tool_calls = function(self, chunk_json)
 			if chunk_json.message and chunk_json.message.tool_calls
 				and type(chunk_json.message.tool_calls) == "table"
 				and #chunk_json.message.tool_calls > 0 then
 				return chunk_json.message
+			end
+			return nil
+		end
+
+        -- [ADD] helper: convert provider error payloads to Oasis chat errors
+		obj._handle_api_error = function(self, chunk_json)
+			if chunk_json and chunk_json.error then
+				local provider_message = tostring(chunk_json.error or "Unknown error")
+				debug:log("oasis.log", "recv_ai_msg", "API Error: " .. provider_message)
+				return chat_error.api_error(self, provider_message)
 			end
 			return nil
 		end
@@ -147,6 +158,12 @@ ollama.new = function()
             -- Raw chunk log after successful JSON parsing (unchanged)
 			debug:log("oasis.log", "recv_ai_msg", chunk)
 
+            -- API error handling
+			local api_error = self:_handle_api_error(chunk_json)
+			if api_error then
+				return nil, nil, self.recv_raw_msg, false, api_error
+			end
+
             -- Tool calls (same conditions and order as before)
 			do
 				local msg_for_tools = self:_has_tool_calls(chunk_json)
@@ -160,7 +177,15 @@ ollama.new = function()
 
             -- If message structure invalid, return as before
 			if not self:_is_valid_message(chunk_json) then
-				return "", "", self.recv_raw_msg, false
+				if chunk_json.done == true then
+					return "", "", self.recv_raw_msg, false
+				end
+				return nil, nil, self.recv_raw_msg, false, chat_error.build(self, {
+					phase = "response_parse",
+					kind = "parse_error",
+					message = "AI response format was not recognized.",
+					provider_message = tostring(chunk),
+				})
 			end
 
             -- Normal response (unchanged)

--- a/oasis/files/usr/lib/lua/oasis/chat/service/openai.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/service/openai.lua
@@ -9,6 +9,7 @@ local misc      = require("oasis.chat.misc")
 local ous       = require("oasis.unified.chat.schema")
 local debug     = require("oasis.chat.debug")
 local calling   = require("oasis.chat.function.calling.openai")
+local chat_error = require("oasis.chat.error")
 
 local openai = {}
 openai.new = function()
@@ -51,12 +52,10 @@ openai.new = function()
         obj._handle_api_error = function(self, chunk_json)
             if chunk_json and chunk_json.error then
                 local error_message = chunk_json.error.message or "Unknown error"
+                local detail = chunk_json.error.type or chunk_json.error.code
                 debug:log("oasis.log", "recv_ai_msg", "API Error: " .. error_message)
-                local error_response = { message = { role = "assistant", content = error_message } }
-                local plain_text_for_console = error_message
-                local response_ai_json = jsonc.stringify(error_response, false)
                 self.chunk_all = ""
-                return plain_text_for_console, response_ai_json, self.recv_raw_msg, false
+                return chat_error.api_error(self, error_message, { detail = detail })
             end
             return nil
         end
@@ -65,9 +64,14 @@ openai.new = function()
             if not chunk_json.choices or type(chunk_json.choices) ~= "table" or #chunk_json.choices == 0 then
                 debug:log("oasis.log", "recv_ai_msg", "Invalid response format: missing or empty choices field")
                 self.chunk_all = ""
-                return false
+                return false, chat_error.build(self, {
+                    phase = "response_parse",
+                    kind = "parse_error",
+                    message = "AI response format was not recognized.",
+                    provider_message = "missing or empty choices field",
+                })
             end
-            return true
+            return true, nil
         end
 
         obj._get_first_message = function(self, chunk_json)
@@ -111,15 +115,18 @@ openai.new = function()
 
             -- 3) API error handling
             do
-                local err_plain, err_json, err_raw, err_tool = self:_handle_api_error(chunk_json)
-                if err_plain ~= nil then
-                    return err_plain, err_json, err_raw, err_tool
+                local err = self:_handle_api_error(chunk_json)
+                if err then
+                    return nil, nil, self.recv_raw_msg, false, err
                 end
             end
 
             -- 4) Verify existence of choices (clear buffer and exit if missing)
-            if not self:_choices_exist(chunk_json) then
-                return "", "", self.recv_raw_msg, false
+            do
+                local ok, err = self:_choices_exist(chunk_json)
+                if not ok then
+                    return nil, nil, self.recv_raw_msg, false, err
+                end
             end
 
             -- 5) Get the first message
@@ -139,7 +146,12 @@ openai.new = function()
             -- 8) Exit if message is invalid (same return semantics as original)
             if not message then
                 debug:log("oasis.log", "recv_ai_msg", "Invalid response format: missing message in choices[1]")
-                return "", "", self.recv_raw_msg, false
+                return nil, nil, self.recv_raw_msg, false, chat_error.build(self, {
+                    phase = "response_parse",
+                    kind = "parse_error",
+                    message = "AI response format was not recognized.",
+                    provider_message = "missing message in choices[1]",
+                })
             end
 
             -- 9) Build normal text response

--- a/oasis/files/usr/lib/lua/oasis/chat/transfer.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/transfer.lua
@@ -9,6 +9,7 @@ local datactrl  = require("oasis.chat.datactrl")
 local ous       = require("oasis.unified.chat.schema")
 local misc      = require("oasis.chat.misc")
 local debug     = require("oasis.chat.debug")
+local chat_error = require("oasis.chat.error")
 
 local M = {}
 local TITLE_AUTO_SET_TIMEOUT_MS = 120000
@@ -42,19 +43,53 @@ end
 -- @param callback function Chunk handler for response body
 function M.post_to_server(service, user_msg_json, callback)
 
-    local easy = curl.easy()
-
-    service:prepare_post_to_server(easy, callback, curl.form(), user_msg_json)
-
-    -- Send Post Request
-    local success = easy:perform()
-
-    if not success then
-        -- TODO: WebUI Error Handling Support
-        print("\27[31m" .. "Error" .. "\27[0m")
+    local easy_ok, easy = pcall(curl.easy)
+    if (not easy_ok) or (not easy) then
+        return chat_error.build(service, {
+            phase = "http_request",
+            kind = "connection_error",
+            message = "Failed to initialize HTTP client.",
+            detail = tostring(easy),
+        })
     end
 
-    easy:close()
+    local function close_easy()
+        pcall(function()
+            easy:close()
+        end)
+    end
+
+    local prepare_ok, prepare_err = pcall(function()
+        service:prepare_post_to_server(easy, callback, curl.form(), user_msg_json)
+    end)
+
+    if not prepare_ok then
+        close_easy()
+        return chat_error.build(service, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = "Failed to prepare AI service request.",
+            detail = tostring(prepare_err),
+        })
+    end
+
+    -- Send Post Request
+    local perform_ok, success, perform_err = pcall(function()
+        return easy:perform()
+    end)
+
+    if (not perform_ok) or (not success) then
+        close_easy()
+        return chat_error.build(service, {
+            phase = "http_request",
+            kind = "connection_error",
+            message = "Failed to communicate with the AI service.",
+            detail = tostring(perform_err or success),
+        })
+    end
+
+    close_easy()
+    return nil
 end
 
 --- Issue a GET request to url and stream response to callback.
@@ -146,7 +181,18 @@ function M.send_user_msg(service, chat)
     local recv_raw_msg = ""
     local tool_used = false
 
-    local usr_msg_json = service:convert_schema(chat)
+    local convert_ok, usr_msg_json = pcall(function()
+        return service:convert_schema(chat)
+    end)
+
+    if (not convert_ok) or (not usr_msg_json) or (#tostring(usr_msg_json) == 0) then
+        return nil, recv_raw_msg, false, chat_error.build(service, {
+            phase = "request_creation",
+            kind = "request_error",
+            message = "Failed to create AI service request body.",
+            detail = tostring(usr_msg_json),
+        })
+    end
 
     -- Debug Message Json Log
     local debug_msg_json = jsonc.stringify(chat, true)
@@ -158,15 +204,52 @@ function M.send_user_msg(service, chat)
     -- Post (Request) and Response
     local text_for_console -- text for console output
     local response_ai_json -- raw json data (Data primarily for use in the Web UI)
+    local recv_error = nil
 
-    M.post_to_server(service, usr_msg_json, function(chunk)
+    local post_error = M.post_to_server(service, usr_msg_json, function(chunk)
+        if recv_error then
+            return
+        end
 
-        text_for_console, response_ai_json, recv_raw_msg, tool_used = service:recv_ai_msg(chunk)
+        local recv_ok, text, response, raw, used, err = pcall(function()
+            return service:recv_ai_msg(chunk)
+        end)
 
-        output_response_msg(format, text_for_console, response_ai_json, tool_used)
+        if not recv_ok then
+            recv_error = chat_error.build(service, {
+                phase = "response_parse",
+                kind = "parse_error",
+                message = "Failed to process the AI service response.",
+                detail = tostring(text),
+            })
+            return
+        end
+
+        if err then
+            recv_error = err
+            return
+        end
+
+        text_for_console = text
+        response_ai_json = response
+        recv_raw_msg = raw
+        tool_used = used
+
+        local output_ok, output_err = pcall(function()
+            output_response_msg(format, text_for_console, response_ai_json, tool_used)
+        end)
+
+        if not output_ok then
+            recv_error = chat_error.build(service, {
+                phase = "internal",
+                kind = "internal_error",
+                message = "Failed to output the AI service response.",
+                detail = tostring(output_err),
+            })
+        end
     end)
 
-    return response_ai_json, recv_raw_msg, tool_used
+    return response_ai_json, recv_raw_msg, tool_used, recv_error or post_error
 end
 
 --- High-level chat flow orchestration.
@@ -197,7 +280,12 @@ function M.chat_with_ai(service, chat)
     -- debug:dump("oasis.log", chat)
 
     -- send user message and receive ai message
-    local tool_info, ai_response_tbl, tool_used = M.send_user_msg(service, chat)
+    local tool_info, ai_response_tbl, tool_used, err = M.send_user_msg(service, chat)
+
+    if err then
+        debug:log("oasis.log", "chat_with_ai", chat_error.format(err))
+        return nil, nil, false, err
+    end
 
     debug:dump("oasis.log", ai_response_tbl)
 
@@ -208,6 +296,18 @@ function M.chat_with_ai(service, chat)
     end
 
     local new_chat_info = nil
+
+    if (not ai_response_tbl)
+        or (not ai_response_tbl.message)
+        or (#tostring(ai_response_tbl.message) == 0) then
+        local empty_err = chat_error.build(service, {
+            phase = "response_parse",
+            kind = "empty_response",
+            message = "AI service returned no assistant message.",
+        })
+        debug:log("oasis.log", "chat_with_ai", chat_error.format(empty_err))
+        return nil, nil, false, empty_err
+    end
 
     if format == common.ai.format.chat then
         -- debug:log("oasis.log", "chat_with_ai", "#ai_response_tbl.message = " .. tostring(#ai_response_tbl.message))
@@ -226,6 +326,12 @@ function M.chat_with_ai(service, chat)
             else
                 datactrl.record_chat_data(service, chat)
             end
+        else
+            return nil, nil, false, chat_error.build(service, {
+                phase = "response_parse",
+                kind = "parse_error",
+                message = "Failed to store the assistant response in chat history.",
+            })
         end
     elseif (format == common.ai.format.output) or (format == common.ai.format.rpc_output) then
 
@@ -247,15 +353,32 @@ function M.chat_with_ai(service, chat)
                     -- Title generation calls the selected AI service through oasis.title and may
                     -- exceed the default ubus timeout on slow local LLMs. Use common.ubus_call()
                     -- so this long-running ubus request has an explicit timeout.
-                    local result = common.ubus_call(
+                    local result, title_err_msg = common.ubus_call(
                         common.db.ubus.object.oasis_title,
                         common.db.ubus.method.auto_set,
                         {id = chat_info.id},
                         TITLE_AUTO_SET_TIMEOUT_MS
-                    ) or {}
+                    )
+                    result = result or {}
+                    if title_err_msg or result.status == common.status.error then
+                        local title_err = chat_error.build(service, {
+                            phase = "title_generation",
+                            kind = "title_error",
+                            message = "Chat title generation failed.",
+                            provider_message = title_err_msg or result.desc,
+                        })
+                        chat_info.warning = title_err
+                        debug:log("oasis.log", "chat_with_ai", chat_error.format(title_err))
+                    end
                     chat_info.title = result.title or "--"
                     new_chat_info = jsonc.stringify(chat_info, false)
                     debug:log("oasis.log", "chat_with_ai", "new_chat_info = " .. new_chat_info)
+                else
+                    return nil, nil, false, chat_error.build(service, {
+                        phase = "response_parse",
+                        kind = "parse_error",
+                        message = "Failed to store the assistant response in chat history.",
+                    })
                 end
             end
         else
@@ -273,6 +396,11 @@ function M.chat_with_ai(service, chat)
                     ous.append_chat_data(service, save_chat)
                 else
                     debug:log("oasis.log", "transfer_setup_msg", "setup_msg returned false, skipping append_chat_data")
+                    return nil, nil, false, chat_error.build(service, {
+                        phase = "response_parse",
+                        kind = "parse_error",
+                        message = "Failed to store the assistant response in chat history.",
+                    })
                 end
             else
                 debug:log("oasis.log", "chat_with_ai", "skip append for tool_calls response")
@@ -284,7 +412,7 @@ function M.chat_with_ai(service, chat)
         ai_response_tbl.message = ai_response_tbl.message:gsub("%s+", "")
     end
 
-    return new_chat_info, ai_response_tbl.message, false
+    return new_chat_info, ai_response_tbl.message, false, nil
 end
 
 return M

--- a/oasis/files/usr/libexec/rpcd/oasis.title
+++ b/oasis/files/usr/libexec/rpcd/oasis.title
@@ -22,6 +22,7 @@ local methods = {
             local common    = require("oasis.common")
             local transfer  = require("oasis.chat.transfer")
             local debug     = require("oasis.chat.debug")
+            local chat_error = require("oasis.chat.error")
 
             debug:log("oasis.log", "auto_set", "\n--- [oasis.title][auto_set] ---")
             local r = {}
@@ -72,11 +73,24 @@ local methods = {
             local chat = load_chat_data(file_path)
             chat.model = uci:get_first(common.db.uci.cfg, common.db.uci.sect.service, "model")
 
-            local _, title = transfer.chat_with_ai(service, chat)
+            local _, title, _, err = transfer.chat_with_ai(service, chat)
+
+            if err then
+                debug:log("oasis.log", "auto_set", chat_error.format(err))
+                r.result = jsonc.stringify({
+                    status = common.status.error,
+                    desc = chat_error.format(err),
+                    error = err,
+                })
+                return r
+            end
 
             if (not title) or (#title == 0) then
                 debug:log("oasis.log", "auto_set", "No title ...")
-                r.result = jsonc.stringify({ status = common.status.error })
+                r.result = jsonc.stringify({
+                    status = common.status.error,
+                    desc = "No title was generated."
+                })
                 return r
             end
 


### PR DESCRIPTION
## Summary

Chat failures are now reported as structured errors where possible. The goal is
to make failures easier to diagnose from both the CLI and LuCI/WebUI without
changing the normal chat flow.

The error output is designed to show:

- which phase failed
- which AI service and model were in use
- the general error type
- the provider error message, when available
- whether the chat session can continue

## Display Format

Structured chat errors are formatted like this:

```text
<message>
Phase: <phase>
AI Service: <service>
Model: <model>
Type: <kind>
Provider: <provider message>
Detail: <detail>
Chat can continue: yes/no
```

`Provider` and `Detail` are only shown when the information is available.

In CLI chat, the formatted message is printed after `Error:`.

In LuCI/WebUI, the same information is displayed as an error notice in the chat
view. The response is also returned as a structured JSON error from the CGI
handler when possible.

## Error Phases

| Phase | Meaning |
| --- | --- |
| `Request creation` | Failed before sending the request to the AI service. |
| `HTTP request` | Failed while communicating with the AI service endpoint. |
| `AI service response` | The AI provider returned an API-level error. |
| `Response parsing` | The response was received but could not be interpreted. |
| `Function Calling` | Function Calling or tool-call handling failed. |
| `Tool execution` | Local tool execution or tool-output handling failed. |
| `Title generation` | Automatic chat title generation failed. |
| `Internal processing` | Oasis internal handling failed outside the above phases. |

## Error Types

| Type | Meaning |
| --- | --- |
| `request error` | Invalid or incomplete request setup. |
| `connection error` | Endpoint communication failed. |
| `timeout` | The request timed out. |
| `API error` | The AI service returned an error response. |
| `parse error` | JSON or provider response parsing failed. |
| `unsupported feature` | The provider rejected Function Calling or tool use. |
| `tool error` | Local tool execution or tool response processing failed. |
| `title error` | Automatic title generation failed. |
| `internal error` | Unexpected Oasis-side failure. |
| `empty response` | The AI service returned no assistant message. |

## Main Messages

| Message | Phase | Type | Main Source | Meaning |
| --- | --- | --- | --- | --- |
| `Failed to initialize HTTP client.` | HTTP request | connection error | `transfer.lua` | Curl could not be initialized. |
| `Failed to prepare AI service request.` | Request creation | request error | `transfer.lua` | Request setup failed before sending. |
| `Failed to communicate with the AI service.` | HTTP request | connection error or timeout | `transfer.lua` | Curl request failed or timed out. |
| `Failed to create AI service request body.` | Request creation | request error | `transfer.lua` | Request payload generation failed. |
| `AI service returned an error.` | AI service response | API error | `error.lua`, service modules | Provider returned an API error. |
| `AI service rejected Function Calling or tool use.` | AI service response | unsupported feature | `error.lua`, service modules | Provider rejected tool definitions or Function Calling parameters. |
| `Failed to process the AI service response.` | Response parsing | parse error | `transfer.lua` | Provider response could not be converted into Oasis chat data. |
| `AI response format was not recognized.` | Response parsing | parse error | service modules | Provider response shape did not match the expected schema. |
| `AI service returned no assistant message.` | Response parsing | empty response | `transfer.lua` | No assistant content was produced after the request completed. |
| `Failed to store the assistant response in chat history.` | Response parsing | parse error | `transfer.lua` | Assistant response could not be appended to chat history. |
| `Failed to output the AI service response.` | Internal processing | internal error | `transfer.lua` | Output processing failed after receiving a response. |
| `Failed to prepare user message.` | Request creation | request error | `main.lua` | User input could not be converted into chat message data. |
| `AI service configuration was not found.` | Request creation | request error | `main.lua` | Selected AI service configuration was missing. |
| `Failed to handle tool output.` | Tool execution | tool error | `main.lua` | Tool output handling failed during Function Calling flow. |
| `Chat title generation failed.` | Title generation | title error | `transfer.lua`, `datactrl.lua` | Automatic title generation failed after the chat response. |
| `No title was generated.` | Title generation | title error | `oasis.title` | Title generation completed without returning a usable title. |
| `Chat processing failed.` | Internal processing | internal error | CGI handler | WebUI chat processing raised an exception or returned no response. |
| `This script only handles POST requests.` | Request creation | request error | CGI handler | WebUI CGI endpoint was called with an unsupported HTTP method. |
| `Invalid content length.` | Request creation | request error | CGI handler | WebUI CGI request had invalid content length metadata. |
| `Failed to parse WebUI chat request.` | Request creation | parse error | CGI handler | WebUI request body could not be parsed as chat input. |

## Provider Error Classification

Provider errors are preserved when available and are shown as `Provider: ...`.

Some provider messages are classified into more specific error types:

- messages such as `does not support tools` are shown as `unsupported feature`
- timeout-related messages are shown as `timeout`
- connection-related messages are shown as `connection error`
- other provider errors are shown as `API error`

Example:

```text
AI service rejected Function Calling or tool use.
Phase: AI service response
AI Service: Ollama
Model: gemma2:2b
Type: unsupported feature
Provider: registry.ollama.ai/library/gemma2:2b does not support tools
Chat can continue: yes
```

## Title Generation Behavior

Automatic title generation errors are treated as non-fatal.

If title generation fails after a successful chat response, the chat itself
should remain usable. In output/RPC style responses, the failure is returned as a
warning when possible.

This avoids crashing the chat flow when title generation is slow, times out, or
returns an invalid response.

## Existing Messages Not Fully Reworked

Some older messages still exist outside the new structured error path:

- `Oasis's RPC function is not enabled.`
- `No argument.`
- `maximum chat turns reached for this chat`
- `setup message error`

These were left mostly unchanged because the current change focuses on chat
request, response, provider, tool, WebUI, and title-generation diagnostics.