### PR TITLE
Fix/10 regression function calling flag

### DIFF
--- a/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
+++ b/oasis/files/usr/lib/lua/oasis/chat/datactrl.lua
@@ -23,13 +23,16 @@ function M.get_ai_service_cfg(arg, opts)
     local cfg = {}
     local uci_ref = common.db.uci
     local ai_ref = common.ai
+    local service_section = uci:get_first(uci_ref.cfg, uci_ref.sect.service)
 
     cfg.identifier = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "identifier", "") or ""
     cfg.api_key    = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "api_key", "") or ""
     cfg.service    = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "name", "") or ""
     cfg.model      = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "model", "") or ""
     cfg.ipaddr     = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "ipaddr", "") or ""
-    cfg.function_calling = uci:get_first(uci_ref.cfg, uci_ref.sect.service, "function_calling", "0") or "0"
+    cfg.function_calling = service_section
+        and uci:get(uci_ref.cfg, service_section, "function_calling")
+        or "0"
 
     if opts and opts.with_storage then
         cfg.path   = uci:get(uci_ref.cfg, uci_ref.sect.storage, "path")

--- a/oasis/files/usr/lib/lua/oasis/common.lua
+++ b/oasis/files/usr/lib/lua/oasis/common.lua
@@ -476,14 +476,6 @@ function M.check_function_calling_enabled(service)
                 value = cfg.function_calling
             end
         end
-
-        if value == nil then
-            value = service.function_calling
-        end
-    end
-
-    if value == nil then
-        value = uci:get_first(db.uci.cfg, db.uci.sect.service, "function_calling", "0")
     end
 
     return tostring(value or "0") == "1"


### PR DESCRIPTION
 ## Summary

  Fixed Function Calling configuration lookup for the selected AI service.

  The `function_calling` option uses `1` for enabled and `0` for disabled. When disabled through LuCI, the option may be removed
  because `0` is also the default value.

  If the selected service does not contain this option, `uci:get_first()` continues searching later service sections and may read
  their `function_calling` value instead.

  The implementation now resolves the selected service section first and reads `function_calling` directly from that section using
  `uci:get()`. A missing option is treated as disabled.